### PR TITLE
fix: uses do worfklow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: docker/build-push-action@v5
+    - uses: actions/checkout@v4
     - name: Build da imagem Docker
       run: |
         docker build . --file Dockerfile --tag my-image-name:$(date +%s)


### PR DESCRIPTION
This pull request updates the workflow for building Docker images to use the recommended GitHub Actions setup. The main change is replacing the use of the `docker/build-push-action` with a manual checkout and build process.

Workflow update:

* Replaced `docker/build-push-action@v5` with `actions/checkout@v4` and a manual `docker build` command in `.github/workflows/docker-image.yml` to streamline and clarify the image build process.